### PR TITLE
Fix #3: UnnecessaryAsync analyzer was not aware of the lack of covariance in the Task Class

### DIFF
--- a/AsyncFixer.Test/UnnecessaryAsyncTests.cs
+++ b/AsyncFixer.Test/UnnecessaryAsyncTests.cs
@@ -218,6 +218,20 @@ class Program
 
             var expected = new DiagnosticResult { Id = DiagnosticIds.UnnecessaryAsync };
             VerifyCSharpDiagnostic(test, expected);
+
+            var fixtest = @"
+using System;
+using System.Threading.Tasks;
+
+class Program
+{
+    Task<int> foo(int i)
+    {
+        return Task.Run(()=>3);
+    }
+}";
+
+            VerifyCSharpFix(test, fixtest);
         }
 
         [Fact]

--- a/AsyncFixer/Helpers.cs
+++ b/AsyncFixer/Helpers.cs
@@ -58,6 +58,11 @@ namespace AsyncFixer
             return method.ReturnType.ToString() == "void";
         }
 
+        public static bool IsImplicitTypeCasting(this TypeInfo typeInfo)
+        {
+            return !SymbolEqualityComparer.Default.Equals(typeInfo.Type, typeInfo.ConvertedType);
+        }
+
         public static T FirstAncestorOrSelfUnderGivenNode<T>(this SyntaxNode node, SyntaxNode parent)
             where T : SyntaxNode
         {


### PR DESCRIPTION
Expression-bodied member support is now aware of the lack of covariance in the Task class