### PR TITLE
Fix #7: Improve AsyncFixer01:UnnecessaryAsync

### DIFF
--- a/AsyncFixer.Test/UnnecessaryAsyncTests.cs
+++ b/AsyncFixer.Test/UnnecessaryAsyncTests.cs
@@ -253,8 +253,7 @@ class Program
         }
 
         // TODO: remove the awaits even though they do not use return statements.
-        [Fact]
-        // [Fact(Skip ="Remove awaits")]
+        [Fact(Skip = "Remove awaits")]
         public void UnnecessaryAsyncTest7()
         {
             var test = @"


### PR DESCRIPTION
- Fix #7, false positives when there are multiple await expressions in the expression-bodied members.
- Fix false negatives when there are await expressions under lambda functions. 
- Fixer got more accurate.