### PR TITLE
UnnecessaryAsync analyzer becomes smarter with dataflow analysis

### DIFF
--- a/AsyncFixer.Test/AsyncCallInsideUsingBlockTests.cs
+++ b/AsyncFixer.Test/AsyncCallInsideUsingBlockTests.cs
@@ -183,7 +183,7 @@ class Program
         using (var stream = new FileStream(""existing"", FileMode.Open))
         {
             await stream.CopyToAsync(newStream);
-            stream.CopyToAsync(Stream.Null); 
+            newStream.CopyToAsync(Stream.Null); 
         }
     }
 }";


### PR DESCRIPTION
Implemented a depth-limited dataflow analysis to get the list of the variable names accessed in the await statement. This is needed to understand whether there are any variables created via `using` statement are accessed in the await statement. If there is one, we cannot remove `async&await` keywords as it can cause `ObjectDisposedException`. 

In the example below, AsyncFixer can see that the last `await` statement involves the disposable object, `stream` created via `using` statement. 
```
async Task foo()
{
    using var stream = new MemoryStream();
    int streamOperation()
    {
        return stream.Read(null);
    }

    Task t = Task.Run(() => streamOperation());
    await t;
}
```

However, in the example below, it is perfectly safe to remove `async&await` keywords: 
```
async Task foo()
{
    using var stream = new MemoryStream();
    stream.Read(null);
    await Task.Delay(1000);
}
```

