### PR TITLE
Correct behavior of AsyncFixer01 on methods that mix Task and ValueTask

### DIFF
--- a/AsyncFixer/Helpers.cs
+++ b/AsyncFixer/Helpers.cs
@@ -63,6 +63,21 @@ namespace AsyncFixer
             return !SymbolEqualityComparer.Default.Equals(typeInfo.Type, typeInfo.ConvertedType);
         }
 
+        public static ExpressionSyntax RemoveConfigureAwait(ExpressionSyntax expression)
+        {
+            var invoc = expression as InvocationExpressionSyntax;
+            if (invoc != null)
+            {
+                var expr = invoc.Expression as MemberAccessExpressionSyntax;
+                if (expr != null && expr.Name.Identifier.ValueText == "ConfigureAwait")
+                {
+                    return expr.Expression;
+                }
+            }
+
+            return expression;
+        }
+
         public static T FirstAncestorOrSelfUnderGivenNode<T>(this SyntaxNode node, SyntaxNode parent)
             where T : SyntaxNode
         {

--- a/AsyncFixer/UnnecessaryAsync/UnnecessaryAsyncFixer.cs
+++ b/AsyncFixer/UnnecessaryAsync/UnnecessaryAsyncFixer.cs
@@ -132,21 +132,10 @@ namespace AsyncFixer.UnnecessaryAsync
 
         private ExpressionSyntax RemoveAwaitFromExpression(AwaitExpressionSyntax awaitExpr)
         {
-            var newExpr = awaitExpr;
+            var trimmedExpr = Helpers.RemoveConfigureAwait(awaitExpr.Expression);
 
-            // If there is some ConfigureAwait(false), remove it 
-            var invoc = awaitExpr.Expression as InvocationExpressionSyntax;
-            if (invoc != null)
-            {
-                var expr = invoc.Expression as MemberAccessExpressionSyntax;
-
-                // TODO: Check whether it is ConfigureAwait(false) or ConfigureAwait(true);
-                if (expr != null && expr.Name.Identifier.ValueText == "ConfigureAwait")
-                {
-                    newExpr = awaitExpr.ReplaceNode(awaitExpr.Expression, expr.Expression);
-                }
-            }
-
+            // TODO: Check whether it is ConfigureAwait(false) or ConfigureAwait(true);
+            var newExpr = awaitExpr.ReplaceNode(awaitExpr.Expression, trimmedExpr);
             return newExpr.Expression.WithAdditionalAnnotations(Simplifier.Annotation);
         }
     }


### PR DESCRIPTION
The following compiles fine in C#:

```csharp
    async ValueTask<int> foo(int x)
    {
        if (x == 0)
            return x;
        await Task.Delay(1);
        return x;
    }

    async Task<int> bar() {
        return await foo(1);
    }
```

AsyncFixer01 doesn't know the difference between `Task` and `ValueTask` an produces the following, which doesn't compile:

```csharp
    async ValueTask<int> foo(int x)
    {
        if (x == 0)
            return x;
        await Task.Delay(1);
        return x;
    }

    Task<int> bar() {
        return foo(1);       // Error!
    }
```

This PR checks that all return values match the signature of the method to emit the warning.