### PR TITLE
AsyncFixer01: Do not warn when the await expressions are in the scope of a using declaration

### DIFF
--- a/AsyncFixer.Test/UnnecessaryAsyncTests.cs
+++ b/AsyncFixer.Test/UnnecessaryAsyncTests.cs
@@ -433,6 +433,81 @@ class Program
         }
 
         /// <summary>
+        /// Do not remove await expressions in using scopes
+        /// Otherwise, the object is disposed early which may have unexpected
+        /// consequences or be semantically incorrect.
+        /// </summary>
+        [Fact]
+        public void NoWarn_AwaitAfterUsingStatement2()
+        {
+            var test = @"
+using System;
+using System.Threading.Tasks;
+using System.IO;
+
+class Program
+{
+    async Task foo()
+    {
+        using var sw = new DisposableStopwatch(onDispose: () => Console.WriteLine(""Finished!"");
+        await Task.Delay(1000);
+    }
+}";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
+        /// <summary>
+        /// Ignore using statements that are in scopes that the fixer won't modify
+        /// </summary>
+        [Fact]
+        public void OutOfScopeUsingDeclaration()
+        {
+            var test = @"
+using System;
+using System.Threading.Tasks;
+
+class Program
+{
+    async Task foo(bool cond)
+    {
+        if (cond)
+        {
+            using var stream = FileStream.Null;
+            int x = 5;
+        }
+
+        var stream = ""Stream"";
+        await Task.Run(() => { Console.WriteLine(stream.Length); });
+    }
+}";
+
+            var expected = new DiagnosticResult { Id = DiagnosticIds.UnnecessaryAsync };
+            VerifyCSharpDiagnostic(test, expected);
+
+            var fixtest = @"
+using System;
+using System.Threading.Tasks;
+
+class Program
+{
+    Task foo(bool cond)
+    {
+        if (cond)
+        {
+            using var stream = FileStream.Null;
+            int x = 5;
+        }
+
+        var stream = ""Stream"";
+        return Task.Run(() => { Console.WriteLine(stream.Length); });
+    }
+}";
+
+            VerifyCSharpFix(test, fixtest);
+        }
+
+        /// <summary>
         /// Do not remove await expressions involving disposable objects inside using block
         /// </summary>
         [Fact]
@@ -574,7 +649,7 @@ class Program
 
             VerifyCSharpDiagnostic(test);
         }
-
+        
         [Fact]
         public void NoWarn_UsingStatement()
         {
@@ -615,7 +690,7 @@ class Program
         }
 
         [Fact]
-        public void NoWarn_UsingStatementWithDataflow()
+        public void NoWarn_UsingStatement3()
         {
             var test = @"
 using System;
@@ -639,7 +714,7 @@ class Program
         }
 
         [Fact]
-        public void NoWarn_UsingStatementWithDataflow2()
+        public void NoWarn_UsingStatement4()
         {
             var test = @"
 using System;
@@ -664,57 +739,7 @@ class Program
         }
 
         [Fact]
-        public void UsingStatementWithDataflow2()
-        {
-            var test = @"
-using System;
-using System.Threading.Tasks;
-
-class Program
-{
-    async Task foo()
-    {
-        using var stream = new MemoryStream();
-        int streamOperation()
-        {
-            var stream2 = new MemoryStream();
-            return stream2.Read(null);
-        }
-        
-        stream.Read(null);
-        var t = Task.Run(() => streamOperation());
-        await t;
-    }
-}";
-            var expected = new DiagnosticResult { Id = DiagnosticIds.UnnecessaryAsync };
-            VerifyCSharpDiagnostic(test, expected);
-
-            var fixtest = @"
-using System;
-using System.Threading.Tasks;
-
-class Program
-{
-    Task foo()
-    {
-        using var stream = new MemoryStream();
-        int streamOperation()
-        {
-            var stream2 = new MemoryStream();
-            return stream2.Read(null);
-        }
-        
-        stream.Read(null);
-        var t = Task.Run(() => streamOperation());
-        return t;
-    }
-}";
-
-            VerifyCSharpFix(test, fixtest);
-        }
-
-        [Fact(Skip = "TODO: fix the dataflow analysis to analyze all locations of the symbol, not only the definitions")]
-        public void NoWarn_UsingStatementWithDataflowComplicated()
+        public void NoWarn_UsingStatement5()
         {
             var test = @"
 using System;

--- a/AsyncFixer.Test/UnnecessaryAsyncTests.cs
+++ b/AsyncFixer.Test/UnnecessaryAsyncTests.cs
@@ -507,6 +507,51 @@ class Program
             VerifyCSharpFix(test, fixtest);
         }
 
+        [Fact]
+        public void OutOfScopeSiblingUsingBlock()
+        {
+            var test = @"
+using System;
+using System.Threading.Tasks;
+
+class Program
+{
+    async Task foo(bool cond)
+    {
+        using (var stream = FileStream.Null)
+        {
+            int x = 5;
+        }
+
+        var stream = ""Stream"";
+        await Task.Run(() => { Console.WriteLine(stream.Length); });
+    }
+}";
+
+            var expected = new DiagnosticResult { Id = DiagnosticIds.UnnecessaryAsync };
+            VerifyCSharpDiagnostic(test, expected);
+
+            var fixtest = @"
+using System;
+using System.Threading.Tasks;
+
+class Program
+{
+    Task foo(bool cond)
+    {
+        using (var stream = FileStream.Null)
+        {
+            int x = 5;
+        }
+
+        var stream = ""Stream"";
+        return Task.Run(() => { Console.WriteLine(stream.Length); });
+    }
+}";
+
+            VerifyCSharpFix(test, fixtest);
+        }
+
         /// <summary>
         /// Do not remove await expressions involving disposable objects inside using block
         /// </summary>

--- a/AsyncFixer/Helpers.cs
+++ b/AsyncFixer/Helpers.cs
@@ -135,6 +135,49 @@ namespace AsyncFixer
                 (oldNode, newNode) => replacementPairs.First(pair => pair.OldNode == oldNode).NewNode
                 );
         }
+
+        /// <summary>
+        /// Return the names of all variables that are read-accessed in the given statement.
+        /// </summary>
+        /// <remarks>
+        /// The method iteratively goes through the definitions to find implicitly-accessed variables. 
+        /// </remarks>
+        public static IEnumerable<string> GetAccessedVariableNamesWithPointsToAnalysis(SemanticModel semanticModel, SyntaxNode root, SyntaxNode node, int depth = 0)
+        {
+            if (depth == 5 || node == null || root == null)
+            {
+                // Put a limit for the call stack frame
+                yield break;
+            }
+
+            var dataFlowResult = semanticModel.AnalyzeDataFlow(node);
+            if (dataFlowResult?.Succeeded == true)
+            {
+                foreach (ISymbol symbol in dataFlowResult.ReadInside)
+                {
+                    yield return symbol.Name;
+
+                    if (symbol.DeclaringSyntaxReferences == null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var syntaxRef in symbol.DeclaringSyntaxReferences)
+                    {
+                        var expressions = root.FindNode(syntaxRef.Span, getInnermostNodeForTie: true).DescendantNodes((n) => !(n is ExpressionSyntax)).OfType<ExpressionSyntax>();
+
+                        foreach (var expr in expressions)
+                        {
+                            var names = GetAccessedVariableNamesWithPointsToAnalysis(semanticModel, root, expr, depth + 1);
+                            foreach (var name in names)
+                            {
+                                yield return name;
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/AsyncFixer/UnnecessaryAsync/UnnecessaryAsyncAnalyzer.cs
+++ b/AsyncFixer/UnnecessaryAsync/UnnecessaryAsyncAnalyzer.cs
@@ -49,7 +49,7 @@ namespace AsyncFixer.UnnecessaryAsync
                 return true;
             }
 
-            // Check sibling nodes for using statements which will be in scope
+            // Check sibling nodes for using declarations which will be in scope
             // Example: 
             //  public async Task Foo() 
             //  {
@@ -63,11 +63,6 @@ namespace AsyncFixer.UnnecessaryAsync
                     // Reached the statement we are considering
                     // No need to keep going
                     break;
-                }
-
-                if (sibling.Kind() == SyntaxKind.UsingStatement)
-                {
-                    return true;
                 }
 
                 if (sibling is LocalDeclarationStatementSyntax declaration)

--- a/AsyncFixer/UnnecessaryAsync/UnnecessaryAsyncAnalyzer.cs
+++ b/AsyncFixer/UnnecessaryAsync/UnnecessaryAsyncAnalyzer.cs
@@ -38,7 +38,7 @@ namespace AsyncFixer.UnnecessaryAsync
             context.RegisterSyntaxNodeAction(AnalyzeMethodDeclaration, SyntaxKind.MethodDeclaration);
         }
 
-        private bool HasUsingOrTryParent(SyntaxNode node, SyntaxNode root)
+        private bool IsInUsingOrTryScope(SyntaxNode node, SyntaxNode root)
         {
             if (node == root) return false;
             var parent = node.Parent;
@@ -49,7 +49,40 @@ namespace AsyncFixer.UnnecessaryAsync
                 return true;
             }
 
-            return HasUsingOrTryParent(parent, root);
+            // Check sibling nodes for using statements which will be in scope
+            // Example: 
+            //  public async Task Foo() 
+            //  {
+            //      using var x = new Disposable();   <-- We want to detect this statement
+            //      await Task.Delay(1);
+            //  }
+            foreach (var sibling in parent.ChildNodes())
+            {
+                if (sibling == node)
+                {
+                    // Reached the statement we are considering
+                    // No need to keep going
+                    break;
+                }
+
+                if (sibling.Kind() == SyntaxKind.UsingStatement)
+                {
+                    return true;
+                }
+
+                if (sibling is LocalDeclarationStatementSyntax declaration)
+                {
+                    if (declaration.UsingKeyword.Kind() == SyntaxKind.UsingKeyword)
+                    {
+                        // Variable declaration with using,
+                        // which will be in scope in the await statement (as in the above example)
+                        return true;
+                    }
+                }
+
+            }
+            
+            return IsInUsingOrTryScope(parent, root);
         }
 
         private void AnalyzeMethodDeclaration(SyntaxNodeAnalysisContext context)
@@ -70,7 +103,6 @@ namespace AsyncFixer.UnnecessaryAsync
             {
                 // Expression-bodied members 
                 // e.g. public static async Task Foo() => await Task.FromResult(true);
-
                 var returnExpressionType = context.SemanticModel.GetTypeInfo(node.ExpressionBody?.Expression);
                 if (returnExpressionType.IsImplicitTypeCasting())
                 {
@@ -97,15 +129,8 @@ namespace AsyncFixer.UnnecessaryAsync
 
             var controlFlow = context.SemanticModel.AnalyzeControlFlow(node.Body);
             var returnStatements = controlFlow?.ReturnStatements ?? ImmutableArray<SyntaxNode>.Empty;
-
-            // Retrieve the disposable object identifiers from the using statements. 
-            // For instance, for the following statement, we'd like to return 'source'.
-            //      using FileStream source = File.Open("data", FileMode.Open);
-            var disposableObjectNames = node.Body.DescendantNodes().OfType<LocalDeclarationStatementSyntax>()
-                .Where(a => a.UsingKeyword.Kind() != SyntaxKind.None)
-                .SelectMany(a => a.DescendantNodes().OfType<VariableDeclaratorSyntax>().Select(b => b.Identifier.ValueText)).ToList();
-
             var numAwait = 0;
+
             if (returnStatements.Any())
             {
                 foreach (var temp in returnStatements)
@@ -162,31 +187,9 @@ namespace AsyncFixer.UnnecessaryAsync
 
             bool IsSafeToRemoveAsyncAwait(StatementSyntax statement)
             {
-                if (HasUsingOrTryParent(statement, node))
+                if (IsInUsingOrTryScope(statement, node))
                 {
                     // If it is under 'using' or 'try' block, it is not safe to remove async/await.
-                    return false;
-                }
-
-                // Make sure that we do not give a warning about the await statement involving an object which is created by an using statement.
-                // We use dataflow analysis to accurately detect a case like below:
-                //  async Task foo()
-                //  {
-                //      using var stream = new MemoryStream();
-                //      int streamOperation()
-                //      {
-                //          return stream.Read(null);
-                //      }
-                //      
-                //      var t = Task.Run(() => streamOperation())
-                //      await t;
-                //  }
-                // In the example above, we need to find out whether 'stream' is accessed in the last statement.
-
-                var names = GetAccessedVariableNamesWithPointsToAnalysis(context.SemanticModel, node, statement).ToList();
-                
-                if (names.Any(a => disposableObjectNames.Contains(a)))
-                {
                     return false;
                 }
 
@@ -194,47 +197,5 @@ namespace AsyncFixer.UnnecessaryAsync
             }
         }
 
-        /// <summary>
-        /// Return the names of all variables that are read-accessed in the given statement.
-        /// </summary>
-        /// <remarks>
-        /// The method iteratively goes through the definitions to find implicitly-accessed variables. 
-        /// </remarks>
-        private IEnumerable<string> GetAccessedVariableNamesWithPointsToAnalysis(SemanticModel semanticModel, SyntaxNode root, SyntaxNode node, int depth = 0)
-        {
-            if (depth == 5 || node == null || root == null)
-            {
-                // Put a limit for the call stack frame
-                yield break;
-            }
-
-            var dataFlowResult = semanticModel.AnalyzeDataFlow(node);
-            if (dataFlowResult?.Succeeded == true)
-            {
-                foreach (ISymbol symbol in dataFlowResult.ReadInside)
-                {
-                    yield return symbol.Name;
-
-                    if (symbol.DeclaringSyntaxReferences == null)
-                    {
-                        continue;
-                    }
-                    
-                    foreach (var syntaxRef in symbol.DeclaringSyntaxReferences)
-                    {
-                        var expressions = root.FindNode(syntaxRef.Span, getInnermostNodeForTie: true).DescendantNodes((n) => !(n is ExpressionSyntax)).OfType<ExpressionSyntax>();
-
-                        foreach (var expr in expressions)
-                        {
-                            var names = GetAccessedVariableNamesWithPointsToAnalysis(semanticModel, root, expr, depth + 1);
-                            foreach (var name in names)
-                            {
-                                yield return name;
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
The current implementation of AsyncFixer01 uses dataflow analysis to deal with `using` declarations: it retrieves the identifiers from all the using declarations and then checks to see if the awaited statements that it wants to remove "read" the variable: the intention is to only avoid "reads" to objects which are potentially disposed, which would lead to undefined behavior.

This approach has two issues, one in the form of a false positive and one in the form of a false negative (details below).

This PR changes the behavior of AsyncFixer01 so that it searches for (all) using declarations within the scope of the awaited expressions, solving both issues. It also moves a now unused function to the Helper class and renames some tests which tested the dataflow aspect.

### False negative
The false negative is a product of using the identifiers of the variables, which can be repeated in non-overlapping scopes. For example, the current implementation wouldn't fix this case:

```csharp 
async Task foo(bool cond)
{
    if (cond)
    {
        using var stream = FileStream.Null;
        int x = 5;
    }

    var stream = "Stream";
    await Task.Run(() => Console.WriteLine(stream.Length));
}
```

because the identifier `stream` is used in the awaited expression. But it is safe to remove the `await` because the `stream` used in the statement is the string and not the disposed instance. This code is arguably in pretty bad style and the variable name should be changed, so if this were the only fix the PR may not be worth it, but it's possible anyways.

### False postive
The false positive (also raised in #18) happens when the awaited expressions don't use the related variables. On a first glance it seems safe, because there is no way to access the disposed object, but the problem is that the disposal itself may have side effects which change the semantics of the program if done early. For example, consider a `DisposableStopwatch` class:

```csharp
class DisposableStopwatch : IDisposable
{
    private Action _beforeDispose;
    private Stopwatch _innerSw = Stopwatch.StartNew();
    public long Elapsed => _innerSw.ElapsedMilliseconds;
    public DisposableStopwatch(Action beforeDispose = null) => _beforeDispose = beforeDispose;  

    public void Dispose()
    {
         _beforeDispose?.Invoke();
    } 
}
```

With this, it isn't correct to change this function:

```csharp
async Task MeasuredLongRunningTask()
{
    using var sw = new DisposableStopwatch(beforeDisposal: () => Console.WriteLine($"Finished in {sw.Elapsed} ms"));
    await LongRunningTask();
}
```

to this:

```csharp
Task MeasuredLongRunningTask()
{
    using var sw = new DisposableStopwatch(beforeDisposal: () => Console.WriteLine($"Finished in {sw.Elapsed} ms"));
    return LongRunningTask();
}
```



